### PR TITLE
change the way jaxb context factory is pointed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 			<resource>
 				<directory>src/main/java</directory>
 				<includes>
-					<include>**/jaxb.index</include>
+					<include>**/jaxb.*</include>
 				</includes>
 			</resource>
 		</resources>

--- a/src/main/java/com/dynatrace/sdk/server/Service.java
+++ b/src/main/java/com/dynatrace/sdk/server/Service.java
@@ -61,11 +61,6 @@ import com.dynatrace.sdk.server.response.models.ErrorResponse;
 
 public abstract class Service {
 
-	static {
-		/** Set jaxb factory to use eclipse implementation. */
-		System.setProperty("javax.xml.bind.context.factory", "org.eclipse.persistence.jaxb.JAXBContextFactory");
-	}
-
 	/** Default API version URI prefix, may be overwritten in constructor. */
 	public final static String API_VER_URI_PREFIX = "/api/v2";
 

--- a/src/main/java/com/dynatrace/sdk/server/response/models/jaxb.properties
+++ b/src/main/java/com/dynatrace/sdk/server/response/models/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/src/main/java/com/dynatrace/sdk/server/sessions/models/jaxb.properties
+++ b/src/main/java/com/dynatrace/sdk/server/sessions/models/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/src/main/java/com/dynatrace/sdk/server/systemprofiles/models/jaxb.properties
+++ b/src/main/java/com/dynatrace/sdk/server/systemprofiles/models/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/src/main/java/com/dynatrace/sdk/server/testautomation/models/jaxb.properties
+++ b/src/main/java/com/dynatrace/sdk/server/testautomation/models/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory


### PR DESCRIPTION
Jaxb context factory passed using jaxb.properties instead statically set system property, due to gradle ecplise plugin failure when second and subsequent builds were triggered